### PR TITLE
Drop trailing comma to compile on Scala 2.11

### DIFF
--- a/src/main/scala/github/gphat/ssf_scala/Client.scala
+++ b/src/main/scala/github/gphat/ssf_scala/Client.scala
@@ -110,7 +110,7 @@ class Client(
       name=name,
       tags=tags,
       indicator=indicator,
-      service=service,
+      service=service
     )
     sample = parent.map({ p =>
       sample.withTraceId(p.traceId).withParentId(p.id)


### PR DESCRIPTION
Hi Cory! Going to send a few PRs with fixes we've developed as we've started to use this internally. Here's the first & simplest.

cc @chimeracoder